### PR TITLE
Add first Vault tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,9 @@ dependencies = []
 
 [project.scripts]
 localpass = "localpass.cli.main:main"
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+pythonpath = "src"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,23 +1,13 @@
 import pytest
 from localpass.vault import Vault
 
-
-def test_vault_add_entry():
+def test_add_entry():
     vault = Vault()
-    vault.add_entry("test", "user", "pass")
-    assert len(vault.entries) == 1
-    assert vault.entries[0]["name"] == "test"
+    vault.add_entry("gmail", "lukasz", "secret123")
 
-
-def test_vault_list_entries():
-    vault = Vault()
-    vault.add_entry("test", "user", "pass")
     entries = vault.list_entries()
+
     assert len(entries) == 1
-
-
-def test_vault_remove_entry():
-    vault = Vault()
-    vault.add_entry("test", "user", "pass")
-    vault.remove_entry("test")
-    assert len(vault.entries) == 0
+    assert entries[0]["name"] == "gmail"
+    assert entries[0]["username"] == "lukasz"
+    assert entries[0]["password"] == "secret123"


### PR DESCRIPTION
First vault test

## Summary by Sourcery

Add an initial test for the Vault entry listing behavior and configure development testing dependencies.

Build:
- Declare a dev optional dependency group with pytest in pyproject.toml to support running tests.

Tests:
- Add a Vault test that verifies entries added are correctly returned by list_entries.