### PR TITLE
docs: mark PlaintextVaultRepository as unsafe for production

### DIFF
--- a/src/localpass/vault/repository.py
+++ b/src/localpass/vault/repository.py
@@ -47,6 +47,12 @@ class VaultRepository(Protocol):
 
 
 class PlaintextVaultRepository:
+    """WARNING: This repository stores vault data in plaintext and is UNSAFE for production use.
+
+    It is intended ONLY for testing, debugging, or isolated environments where security is not a concern.
+    Do not use this in any environment where data confidentiality is required.
+    """
+
     def load(self, path: str | Path, master_password: str | None = None) -> Vault:
         try:
             data = json.loads(Path(path).read_text())


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add an explicit warning docstring marking PlaintextVaultRepository as unsafe for production and suitable only for testing or non-confidential environments.